### PR TITLE
bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash = "6ec1dc74efacf2cda936b4a6cf4082ce224c76763bdec9f17e437c8cfcaa9953" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
I just ran `conda install tqdm`, and got:
```
Solving package specifications: .
Warning: 2 possible package resolutions (only showing differing packages):
  - conda-forge::tqdm-4.15.0-py36_0
  - conda-forge::tqdm-4.15.0-py_0
```

It chose to install the `tqdm: 4.15.0-py36_0` one.

This isn't really a _problem_, per se, but #15 probably should have bumped the build number so this doesn't happen. This PR would release a new build so that conda actually uses the `noarch: python` version.