### PR TITLE
add missing importlib_resources dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5331&branchName=master">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=master">
         <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tqdm-feedstock?branchName=master">
       </a>
     </td>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   noarch: python
   entry_points:
     - tqdm = tqdm.cli:main
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -24,6 +24,7 @@ requirements:
   run:
     - python >=2.7
     - colorama
+    - importlib_resources # [py<37]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
 
 build:
+  noarch: python
   entry_points:
     - tqdm = tqdm.cli:main
   number: 1
@@ -23,7 +24,7 @@ requirements:
   run:
     - python >=2.7
     - colorama
-    - importlib_resources  # [py<37]
+    - importlib_resources
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
 
 build:
-  noarch: python
   entry_points:
     - tqdm = tqdm.cli:main
   number: 1
@@ -24,7 +23,7 @@ requirements:
   run:
     - python >=2.7
     - colorama
-    - importlib_resources # [py<37]
+    - importlib_resources  # [py<37]
 
 test:
   requires:


### PR DESCRIPTION
A new dependency was added to tqdm https://github.com/tqdm/tqdm/pull/1302 but wasn't packaged in https://github.com/conda-forge/tqdm-feedstock/pull/113 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
