### PR TITLE
Recipe cleanup and no name in context

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,5 +8,5 @@ conda_build:
   pkg_format: '2'
 conda_build_tool: rattler-build
 noarch_platforms:
-- linux_64
-- win_64
+  - linux_64
+  - win_64

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,19 +1,18 @@
 schema_version: 1
 
 context:
-  name: tqdm
   version: "4.68.2"
 
 package:
-  name: ${{ name }}
+  name: tqdm
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/t/tqdm/tqdm-${{ version }}.tar.gz
   sha256: 89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
   python:
@@ -24,7 +23,7 @@ requirements:
   host:
     - python ${{ python_min }}.*
     - pip
-    - setuptools
+    - setuptools >=42
     - setuptools_scm >=3.4
     - toml
   run:
@@ -37,6 +36,7 @@ requirements:
       then: __unix
   run_constraints:
     - envwrap >=0.2
+    - ipywidgets>=6.0
 
 tests:
   - python:
@@ -52,7 +52,7 @@ tests:
         - pyproject.toml
     requirements:
       run:
-        - pytest
+        - pytest >=6.0
         - pytest-cov
         - pytest-timeout
         - pytest-asyncio >=0.24

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,7 @@ requirements:
       then: __unix
   run_constraints:
     - envwrap >=0.2
-    - ipywidgets>=6.0
+    - ipywidgets >=6.0
 
 tests:
   - python:


### PR DESCRIPTION
This PR does some general recipe cleanup and removes the `name` from the context, in accordance with the recommendation in https://github.com/conda-forge/conda-forge.github.io/issues/2712

Adding the name in the context adds nothing and makes it harder to check the src tarball from pypi since you have to manually do the string substitution. Additionally the examples in `staged-recipes` do not use the name in the context:
https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml#L14-L22

The one potentially valid use is in `run_exports` which doesn't apply here. 